### PR TITLE
Upd: Generate Stackage LTS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .stack-work
 Paths_stackage2nix.hs
 /*.nix
+/result*

--- a/src/Distribution/Nixpkgs/Haskell/FromStack.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromStack.hs
@@ -32,6 +32,9 @@ data PackageConfig = PackageConfig
 removeTests :: GenericPackageDescription -> GenericPackageDescription
 removeTests gd = gd { condTestSuites = [] }
 
+removeBenches :: GenericPackageDescription -> GenericPackageDescription
+removeBenches gd = gd { condBenchmarks = [] }
+
 planDependencies :: PackagePlan -> [Dependency]
 planDependencies = map makeDependency . Map.toList . sdPackages . ppDesc
  where
@@ -57,6 +60,9 @@ fromPackage conf pconf plan pkg =
     configureTests
       | pcTests constraints == Don'tBuild = removeTests
       | otherwise = id
+    configureBenches
+      | pcBenches constraints == Don'tBuild = removeBenches
+      | otherwise = id
     flags = Map.toList (pcFlagOverrides constraints)
     (descr, missingDeps) = finalizeGenericPackageDescription
       (haskellResolver conf)
@@ -64,7 +70,7 @@ fromPackage conf pconf plan pkg =
       (targetCompiler conf)
       flags
       (planDependencies plan)
-      (configureTests (pkgCabal pkg))
+      (configureBenches . configureTests $ pkgCabal pkg)
     genericDrv = fromPackageDescription
       (haskellResolver conf)
       (nixpkgsResolver conf)

--- a/src/Distribution/Nixpkgs/Haskell/FromStack.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromStack.hs
@@ -27,8 +27,7 @@ data PackageSetConfig = PackageSetConfig
 
 data PackageConfig = PackageConfig
   { enableCheck     :: Bool
-  , enableHaddock   :: Bool
-  , enableBenchmark :: Bool }
+  , enableHaddock   :: Bool }
 
 removeTests :: GenericPackageDescription -> GenericPackageDescription
 removeTests gd = gd { condTestSuites = [] }
@@ -93,4 +92,3 @@ finalizePackage pkg pconf drv = drv
   & src .~ pkgSource pkg
   & doCheck &&~ enableCheck pconf
   & runHaddock &&~ enableHaddock pconf
-  & benchmarkDepends %~ if enableBenchmark pconf then id else const mempty

--- a/src/Distribution/Nixpkgs/Haskell/FromStack/Package.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromStack/Package.hs
@@ -22,10 +22,12 @@ import qualified Data.Map as Map
 import qualified Data.Set as Set
 
 data Node = Node
-  { _nodeDerivation   :: Derivation
-  , _nodeTestDepends  :: Set.Set String
-  , _nodeBenchmarkDepends :: Set.Set String
-  , _nodeOtherDepends :: Set.Set String }
+  { _nodeDerivation        :: Derivation
+  , _nodeTestDepends       :: Set.Set String
+  , _nodeBenchmarkDepends  :: Set.Set String
+  , _nodeExecutableDepends :: Set.Set String
+  , _nodeSetupDepends      :: Set.Set String
+  , _nodeOtherDepends      :: Set.Set String }
 
 makeLenses ''Node
 
@@ -43,6 +45,8 @@ mkNode _nodeDerivation = Node{..}
       $ view (s . (haskell <> tool)) _nodeDerivation
     _nodeTestDepends = haskellDependencies testDepends
     _nodeBenchmarkDepends = haskellDependencies benchmarkDepends
+    _nodeExecutableDepends = haskellDependencies executableDepends
+    _nodeSetupDepends = haskellDependencies setupDepends
     _nodeOtherDepends = haskellDependencies (executableDepends <> libraryDepends)
 
 nodeName :: Node -> String
@@ -52,7 +56,11 @@ nodeCycleDepends :: Node -> Set.Set String
 nodeCycleDepends = _nodeTestDepends <> _nodeOtherDepends
 
 nodeDepends :: Node -> Set.Set String
-nodeDepends = _nodeTestDepends <> _nodeOtherDepends <> _nodeBenchmarkDepends
+nodeDepends = _nodeTestDepends
+  <> _nodeOtherDepends
+  <> _nodeBenchmarkDepends
+  <> _nodeExecutableDepends
+  <> _nodeSetupDepends
 
 findCycles :: [Node] -> [[Node]]
 findCycles nodes = mapMaybe cyclic $

--- a/src/Distribution/Nixpkgs/Haskell/FromStack/Package.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromStack/Package.hs
@@ -106,9 +106,9 @@ isFromHackage b = case view (reference . Nix.path) b of
 
 pPrintOutConfig :: SystemInfo -> [Node] -> Doc
 pPrintOutConfig systemInfo nodes = vcat
-  [ "{ pkgs }:"
+  [ "{ pkgs, haskellLib }:"
   , ""
-  , "with pkgs.haskell.lib; self: super: {"
+  , "with haskellLib; self: super: {"
   , ""
   , "  # core packages"
   , nest 2 $ vcat $

--- a/src/Distribution/Nixpkgs/Haskell/Stack.hs
+++ b/src/Distribution/Nixpkgs/Haskell/Stack.hs
@@ -97,8 +97,7 @@ packageDerivation conf optHackageDb stackPackage = do
     isExtraDep = stackPackage ^. spExtraDep
     pconf = PackageConfig
       { enableCheck = if isExtraDep then conf ^. spcDoCheckStackage else conf ^. spcDoCheckPackages
-      , enableHaddock = if isExtraDep then conf ^. spcDoHaddockStackage else conf ^. spcDoHaddockPackages
-      , enableBenchmark = not isExtraDep }
+      , enableHaddock = if isExtraDep then conf ^. spcDoHaddockStackage else conf ^. spcDoHaddockPackages }
   return $ finalizePackage pkg pconf drv
 
 genericPackageDerivation

--- a/src/Runner.hs
+++ b/src/Runner.hs
@@ -91,8 +91,8 @@ run = do
       let
         buildPlanFile = LH.buildPlanFilePath (opts ^. optLtsHaskellRepo) stackResolver
         packageConfig = PackageConfig
-          { enableCheck     = opts ^. optDoCheckStackage
-          , enableHaddock   = opts ^. optDoHaddockStackage }
+          { enableCheck     = True
+          , enableHaddock   = True }
       buildPlan <- LH.loadBuildPlan buildPlanFile
       packageSetConfig <- LH.buildPackageSetConfig
         (opts ^. optHackageDb)

--- a/src/Runner.hs
+++ b/src/Runner.hs
@@ -98,11 +98,14 @@ run = do
         buildPlan
       nodes <- traverse (uncurry (buildNode packageSetConfig packageConfig))
         $ Map.toAscList (bpPackages buildPlan)
+      let overrideConfig = mkOverrideConfig opts (siGhcVersion $ bpSystemInfo buildPlan)
 
       writeOutFile buildPlanFile (opts ^. optOutStackagePackages)
         $ pPrintOutPackages (view nodeDerivation <$> nodes)
       writeOutFile buildPlanFile (opts ^. optOutStackageConfig)
         $ pPrintOutConfig (bpSystemInfo buildPlan) nodes
+      writeOutFile buildPlanFile (opts ^. optOutDerivation)
+        $ PP.pPrintHaskellPackages overrideConfig
 
 writeOutFile :: Show source => source -> FilePath -> Doc -> IO ()
 writeOutFile source filePath contents =

--- a/stack-ghc-822.yaml
+++ b/stack-ghc-822.yaml
@@ -1,1 +1,1 @@
-resolver: nightly-2017-12-08
+resolver: lts-10.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-stack-ghc-802.yaml
+stack-ghc-822.yaml


### PR DESCRIPTION
- Output `default.nix` when generating packages from `--resolver`
- Remove benchmarks only marked `Don'tBuild` in stackage build plan
- Update derivation structure according to changes in Nixpkgs
- Build project with `lts-10.0`