### PR TITLE
Upd: use makePackageSet when generating stackage

### DIFF
--- a/src/Distribution/Nixpkgs/Haskell/Stack/PrettyPrinting.hs
+++ b/src/Distribution/Nixpkgs/Haskell/Stack/PrettyPrinting.hs
@@ -19,10 +19,10 @@ import           Stack.Config (StackResolver, unStackResolver)
 
 
 data OverrideConfig = OverrideConfig
-  { _ocGhc              :: !Version
-  , _ocStackagePackages :: !FilePath
-  , _ocStackageConfig   :: !FilePath
-  , _ocNixpkgs          :: !FilePath
+  { _ocGhc              :: Version
+  , _ocStackagePackages :: FilePath
+  , _ocStackageConfig   :: FilePath
+  , _ocNixpkgs          :: FilePath
   }
 
 makeLenses ''OverrideConfig

--- a/src/Stack/Types.hs
+++ b/src/Stack/Types.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Stack.Types where
 
 import Control.Lens
@@ -8,8 +6,8 @@ import System.FilePath
 
 
 data StackYaml = StackYaml
-  { _syDirName  :: !FilePath
-  , _syFileName :: !FilePath }
+  { _syDirName  :: FilePath
+  , _syFileName :: FilePath }
   deriving (Ord, Eq, Show)
 
 makeLenses ''StackYaml


### PR DESCRIPTION
close #47 

When building Stackage LTS from `--resolver` flag, _stackage2nix_ will generate Haskell packages set with `makePackagesSet` function instead of direct call to `<nixpkgs/pkgs/development/haskell-modules>`