### PR TITLE
removes use of <nixpkgs> inside of nix output

### DIFF
--- a/src/Distribution/Nixpkgs/Haskell/Stack/PrettyPrinting.hs
+++ b/src/Distribution/Nixpkgs/Haskell/Stack/PrettyPrinting.hs
@@ -137,7 +137,7 @@ pPrintHaskellPackages oc = vcat
     , attr "compilerConfig" . importStackageConfig $ oc ^. ocStackageConfig
     , ""
     , attr "configurationCommon" "if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {}"
-    , attr "configurationNix" "import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; }"
+    , attr "configurationNix" "import (pkgs.path + \"/pkgs/development/haskell-modules/configuration-nix.nix\") { inherit pkgs haskellLib; }"
     , ""
     , attr "extensible-self" "makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))))"
     ]


### PR DESCRIPTION
Because the <nixpkgs> import was in the middle of the source it was not
possible to pin the version by passing it as an argument.