### PR TITLE
Fix compatibility under NixOS 18.03

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
       - curl https://nixos.org/nix/install | sh
       - source ~/.nix-profile/etc/profile.d/nix.sh
       # nixpkgs-unstable not supported
-      - nix-channel --add https://nixos.org/channels/nixos-17.09 nixpkgs
+      - nix-channel --add https://nixos.org/channels/nixos-18.03 nixpkgs
       - nix-channel --update
       script:
       - nix-env -i cabal-install

--- a/nix/haskell-packages/default.nix
+++ b/nix/haskell-packages/default.nix
@@ -87,6 +87,7 @@ let
   
 in callPackage (nixpkgs.path + "/pkgs/development/haskell-modules") {
   ghc = pkgs.haskell.compiler.ghc822;
+  buildHaskellPackages = buildPackages.haskell.packages.ghc822;
   compilerConfig = self: extends pkgOverrides (stackageConfig self);
   initialPackages = stackagePackages;
   configurationCommon = args: self: super: {};

--- a/src/Distribution/Nixpkgs/Haskell/Stack/PrettyPrinting.hs
+++ b/src/Distribution/Nixpkgs/Haskell/Stack/PrettyPrinting.hs
@@ -79,14 +79,16 @@ overrideHaskellPackages oc packages = vcat
     ]
   , "in callPackage (nixpkgs.path + \"/pkgs/development/haskell-modules\") {"
   , nest 2 $ vcat
-    [ attr "ghc" ("pkgs.haskell.compiler." <> toNixGhcVersion (oc ^. ocGhc))
+    [ attr "ghc" ("pkgs.haskell.compiler." <> nixGhc)
+    , attr "buildHaskellPackages" ("buildPackages.haskell.packages." <> nixGhc)
     , attr "compilerConfig" "self: extends pkgOverrides (stackageConfig self)"
     , attr "initialPackages" "stackagePackages"
     , attr "configurationCommon" "args: self: super: {}"
     , "inherit haskellLib;"
     ]
   , "}"
-  ]
+  ] where
+        nixGhc = toNixGhcVersion (oc ^. ocGhc)
 
 overrideStackage :: StackResolver -> FilePath -> NonEmpty Derivation -> Doc
 overrideStackage stackResolver nixpkgsPath packages = vcat


### PR DESCRIPTION
The generated Nix expressions fail to build under NixOS 18.03, due to the addition of `buildHaskellPackages`. This PR fixes this, and updates `stackage2nix`'s own Nix files to match.