### PR TITLE
WIP Change the way sha1 is resolved to .cabal-file content

### DIFF
--- a/stackage2nix.cabal
+++ b/stackage2nix.cabal
@@ -38,11 +38,10 @@ library
                      , cabal2nix >= 2.7.2
                      , containers
                      , deepseq
+                     , directory
                      , distribution-nixpkgs >= 1.1
                      , exceptions > 0.8
                      , filepath
-                     , gitlib > 3
-                     , gitlib-libgit2 > 3
                      , hopenssl > 2.2
                      , inflections >= 0.3
                      , language-nix


### PR DESCRIPTION
Part of https://github.com/typeable/stackage2nix/issues/41

Requires https://github.com/typeable/nixpkgs-stackage/pull/26

Maybe the old .git code-path should be supported also. So both a
manual checkout and a nix-built all-cabal hashes can be used.