### PR TITLE
Generate separate Nix function for stack.yaml packages

### DIFF
--- a/src/Runner/Cli.hs
+++ b/src/Runner/Cli.hs
@@ -46,19 +46,20 @@ data StackageOptions = StackageOptions
 makeLenses ''StackageOptions
 
 data Options = Options
-  { _optAllCabalHashesRepo  :: Maybe FilePath
-  , _optLtsHaskellRepo      :: Maybe FilePath
-  , _optOutStackagePackages :: FilePath
-  , _optOutStackageConfig   :: FilePath
-  , _optOutDerivation       :: FilePath
-  , _optDoCheckPackages     :: Bool
-  , _optDoHaddockPackages   :: Bool
-  , _optTweaks              :: Tweaks
-  , _optHackageDb           :: Maybe FilePath
-  , _optNixpkgsRepository   :: FilePath
-  , _optCompilerId          :: CompilerId
-  , _optPlatform            :: Platform
-  , _optConfigOrigin        :: ConfigOrigin
+  { _optAllCabalHashesRepo   :: Maybe FilePath
+  , _optLtsHaskellRepo       :: Maybe FilePath
+  , _optOutStackagePackages  :: FilePath
+  , _optOutStackageConfig    :: FilePath
+  , _optOutDerivation        :: FilePath
+  , _optOutStackYamlPackages :: FilePath
+  , _optDoCheckPackages      :: Bool
+  , _optDoHaddockPackages    :: Bool
+  , _optTweaks               :: Tweaks
+  , _optHackageDb            :: Maybe FilePath
+  , _optNixpkgsRepository    :: FilePath
+  , _optCompilerId           :: CompilerId
+  , _optPlatform             :: Platform
+  , _optConfigOrigin         :: ConfigOrigin
   } deriving (Show)
 
 makeLenses ''Options
@@ -79,6 +80,7 @@ options = Options
   <*> outStackagePackages
   <*> outStackageConfig
   <*> outDerivation
+  <*> outStackYamlPackages
   <*> doCheckPackages
   <*> doHaddockPackages
   <*> tweaks
@@ -138,6 +140,14 @@ outDerivation = option str
     <> metavar "NIX_FILE"
     <> help "path to output derivation"
     <> value "default.nix"
+    <> showDefaultWith id )
+
+outStackYamlPackages :: Parser FilePath
+outStackYamlPackages = option str
+  ( long "out-stack-yaml-packages"
+    <> metavar "NIX_FILE"
+    <> help "path to output stackage.yaml packages list"
+    <> value "stack-yaml-packages.nix"
     <> showDefaultWith id )
 
 doCheckPackages :: Parser Bool

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -190,5 +190,6 @@ readStackConfig stackYaml = do
       PlFilePath p -> PlFilePath $ stackYaml ^. syDirName </> p
       packageLocation -> packageLocation
     mkStackConfig = over (scPackages . traversed . spLocation) relativeToStackYaml
+      . over (scExtraDeps . traversed . spLocation) relativeToStackYaml
       . fromYamlConfig
   second mkStackConfig . decodeEither <$> BS.readFile (stackYaml ^. syFilePath)

--- a/test/Stack/ConfigSpec.hs
+++ b/test/Stack/ConfigSpec.hs
@@ -51,6 +51,7 @@ minimalConf = StackConfig
   { _scResolver  = StackResolver "lts-10.0"
   , _scPackages  = NE.fromList
     [ StackPackage (PlFilePath ".") False Nothing]
+  , _scExtraDeps = []
   }
 
 packageDefaultBs :: ByteString
@@ -73,10 +74,11 @@ packages:
 
 packageSimpleListConf :: StackConfig
 packageSimpleListConf = StackConfig
-  { _scResolver = StackResolver "lts-10.0"
-  , _scPackages = NE.fromList
+  { _scResolver  = StackResolver "lts-10.0"
+  , _scPackages  = NE.fromList
     [ StackPackage (PlFilePath "client") False Nothing
     , StackPackage (PlFilePath "server") False Nothing ]
+  , _scExtraDeps = []
   }
 
 packageLocationsBs :: ByteString
@@ -102,11 +104,12 @@ packages:
 
 packageLocationsConf :: StackConfig
 packageLocationsConf = StackConfig
-  { _scResolver = StackResolver "lts-10.0"
-  , _scPackages = NE.fromList
+  { _scResolver  = StackResolver "lts-10.0"
+  , _scPackages  = NE.fromList
     [ StackPackage (PlFilePath "humble/package") False (Just "client")
-    , StackPackage (PlFilePath "humble/package") False (Just "server")
-    , StackPackage (PlUri $ stUri "https://example.com/foo/bar/baz-0.0.2.tar.gz") True (Just "extra")
+    , StackPackage (PlFilePath "humble/package") False (Just "server") ]
+  , _scExtraDeps =
+    [ StackPackage (PlUri $ stUri "https://example.com/foo/bar/baz-0.0.2.tar.gz") True (Just "extra")
     , StackPackage (PlRepo $ Repo (Vcs "git") "git@github.com:example/mega-repo" "6a86ee32e5b869a877151f74064572225e1a0000") True (Just "subdir1")
     , StackPackage (PlRepo $ Repo (Vcs "git") "git@github.com:example/mega-repo" "6a86ee32e5b869a877151f74064572225e1a0000") True (Just "subdir2")
     ]
@@ -122,10 +125,10 @@ extra-deps:
 
 packageExtraDepsConf :: StackConfig
 packageExtraDepsConf = StackConfig
-  { _scResolver = StackResolver "lts-10.0"
-  , _scPackages = NE.fromList
-    [ StackPackage (PlFilePath ".") False Nothing
-    , StackPackage (PlIndex $ PackageIndex "acme-missiles-0.3" Nothing) True Nothing
+  { _scResolver  = StackResolver "lts-10.0"
+  , _scPackages  = NE.fromList [ StackPackage (PlFilePath ".") False Nothing ]
+  , _scExtraDeps =
+    [ StackPackage (PlIndex $ PackageIndex "acme-missiles-0.3" Nothing) True Nothing
     , StackPackage (PlIndex $ PackageIndex "humble-package-1" Nothing) True Nothing ]
   }
 
@@ -142,11 +145,12 @@ extra-deps:
 
 packageMixedConf :: StackConfig
 packageMixedConf = StackConfig
-  { _scResolver = StackResolver "lts-10.0"
-  , _scPackages = NE.fromList
+  { _scResolver  = StackResolver "lts-10.0"
+  , _scPackages  = NE.fromList
     [ StackPackage (PlFilePath "client") False Nothing
-    , StackPackage (PlFilePath "server") False Nothing
-    , StackPackage (PlIndex $ PackageIndex "acme-missiles-0.3" Nothing) True Nothing
+    , StackPackage (PlFilePath "server") False Nothing ]
+  , _scExtraDeps =
+    [ StackPackage (PlIndex $ PackageIndex "acme-missiles-0.3" Nothing) True Nothing
     , StackPackage (PlIndex $ PackageIndex "humble-package-1" Nothing) True Nothing ]
   }
 
@@ -172,10 +176,10 @@ extra-deps:
 
 packageExtraDepsNewConf :: StackConfig
 packageExtraDepsNewConf = StackConfig
-  { _scResolver = StackResolver "lts-10.0"
-  , _scPackages = NE.fromList
-    [ StackPackage (PlFilePath ".") False Nothing
-    , StackPackage (PlFilePath "vendor/lib") True Nothing
+  { _scResolver  = StackResolver "lts-10.0"
+  , _scPackages  = NE.fromList [ StackPackage (PlFilePath ".") False Nothing ]
+  , _scExtraDeps =
+    [ StackPackage (PlFilePath "vendor/lib") True Nothing
     , StackPackage (PlIndex $ PackageIndex "acme-missiles-0.3" Nothing) True Nothing
     , StackPackage (PlRepo $ Repo (Vcs "git") "git@github.com:yesodweb/wai" "2f8a8e1b771829f4a8a77c0111352ce45a14c30f") True (Just "auto-update")
     , StackPackage (PlRepo $ Repo (Vcs "git") "git@github.com:yesodweb/wai" "2f8a8e1b771829f4a8a77c0111352ce45a14c30f") True (Just "wai")


### PR DESCRIPTION
Generate Nix function that filters root packages from stack.yaml

Example usage with `shellFor`:

```
let
  # generated packages
  stackagePackages  = import ./. {};
  stackYamlPackages = import ./stackage/stack-yaml-packages.nix stackagePackages;
in stackagePackages.shellFor {
  packages = _: lib.mapAttrsToList (_: pkg: pkg) stackYamlPackages;
}
```