### PR TITLE
Fix up Parse -> Parsec, misc. other Cabal 2.2+ changes.

### DIFF
--- a/src/Distribution/Nixpkgs/Haskell/FromStack.hs
+++ b/src/Distribution/Nixpkgs/Haskell/FromStack.hs
@@ -68,14 +68,14 @@ fromPackage conf pconf plan pkg =
       (haskellResolver conf)
       (targetPlatform conf)
       (targetCompiler conf)
-      flags
+      (mkFlagAssignment flags)
       (planDependencies plan)
       (configureBenches . configureTests $ pkgCabal pkg)
     genericDrv = fromPackageDescription
       (haskellResolver conf)
       (nixpkgsResolver conf)
       missingDeps
-      flags
+      (mkFlagAssignment flags)
       descr
     depName (Dependency name _) = name
     testDeps = setOf

--- a/src/Distribution/Nixpkgs/Haskell/Packages/PrettyPrinting.hs
+++ b/src/Distribution/Nixpkgs/Haskell/Packages/PrettyPrinting.hs
@@ -2,6 +2,8 @@ module Distribution.Nixpkgs.Haskell.Packages.PrettyPrinting where
 
 import Language.Nix.PrettyPrinting
 
+import Prelude hiding ((<>))
+
 compilerConfig :: Doc -> Doc
 compilerConfig body =
   funargsCurried ["self", "super"] <+> body

--- a/src/Distribution/Nixpkgs/Haskell/Stack/PrettyPrinting.hs
+++ b/src/Distribution/Nixpkgs/Haskell/Stack/PrettyPrinting.hs
@@ -17,6 +17,8 @@ import qualified Language.Nix.FilePath as Nix
 import           Language.Nix.PrettyPrinting as PP
 import           Stack.Config (StackResolver, unStackResolver)
 
+import           Prelude hiding ((<>))
+
 
 data OverrideConfig = OverrideConfig
   { _ocGhc              :: Version

--- a/src/Runner.hs
+++ b/src/Runner.hs
@@ -189,6 +189,6 @@ mkStackPackagesConfig opts = StackPackagesConfig
   , _spcNixpkgsResolver   = \i -> Just (Nix.binding # (i, Nix.path # [i]))
   , _spcTargetPlatform    = opts ^. optPlatform
   , _spcTargetCompiler    = unknownCompilerInfo (opts ^. optCompilerId) NoAbiTag
-  , _spcFlagAssignment    = []
+  , _spcFlagAssignment    = mempty
   , _spcDoCheckPackages   = opts ^. optDoCheckPackages
   , _spcDoHaddockPackages = opts ^. optDoHaddockPackages }

--- a/stackage2nix.cabal
+++ b/stackage2nix.cabal
@@ -31,7 +31,7 @@ library
                      , LtsHaskell
                      , Paths_stackage2nix
   build-depends:       base > 4.7 && < 5
-                     , Cabal > 2
+                     , Cabal > 2.2
                      , QuickCheck
                      , aeson
                      , bytestring


### PR DESCRIPTION
This fixes up stackage2nix for Cabal-2.2+, but breaks backwards compatibility. If it's desired to continue supporting older Cabal versions, CPP could be used at these sites. However, given that backwards-incompatible changes WRT Nix have already been made, the value of doing so is unclear. It's already necessary to use older versions of stackage2nix when using a nixpkgs checkout with older factorings of Haskell packages (unless I'm doing something wrong/missing something).