### PR TITLE
Use git to read .cabal files by name

### DIFF
--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -23,7 +23,7 @@ rec {
     buildInputs = [ git ];
     installPhase = ''
       mkdir -p $out
-      git clone --branch hackage https://github.com/commercialhaskell/all-cabal-hashes.git $out
+      git clone --bare --branch hackage https://github.com/commercialhaskell/all-cabal-hashes.git $out
     '';
     SSL_CERT_FILE="${cacert}/etc/ssl/certs/ca-bundle.crt";
   };

--- a/stackage2nix.cabal
+++ b/stackage2nix.cabal
@@ -51,6 +51,7 @@ library
                      , optparse-applicative
                      , pretty
                      , stackage-curator >= 0.15
+                     , tagged
                      , text
                      , unordered-containers
                      , yaml


### PR DESCRIPTION
This allows a bare checkout of `all-cabal-hashes`, which saves some space and removes a lot of separate files.

But it also means that we'll be able represent a whole `all-cabal-hashes` repo as a single git .pack-file.

Making that .pack-file reproducible will be a final thing to achieve #41.