### PR TITLE
Use configureCabalFlags from cabal2nix

### DIFF
--- a/src/Distribution/Nixpkgs/Haskell/Stack.hs
+++ b/src/Distribution/Nixpkgs/Haskell/Stack.hs
@@ -33,6 +33,7 @@ getStackPackageFromDb :: DB.HackageDB -> StackPackage -> IO Package
 getStackPackageFromDb hackageDb stackPackage = do
   PackageSourceSpec.getPackage'
     False
+    False
     (pure hackageDb)
     (stackLocationToSource (stackPackage ^. spLocation) (stackPackage ^. spDir))
 

--- a/src/LtsHaskell.hs
+++ b/src/LtsHaskell.hs
@@ -46,7 +46,7 @@ getPackageFromRepo allCabalHashesPath mSha1Hash pkgId = do
     tarballSHA256 = fromMaybe
       (error (display pkgId ++ ": meta data has no SHA256 hash for the tarball"))
       (view (mHashes . at "SHA256") meta)
-    source = DerivationSource "url" ("mirror://hackage/" ++ display pkgId ++ ".tar.gz") "" tarballSHA256
+    source = DerivationSource "url" ("mirror://hackage/" ++ display pkgId ++ ".tar.gz") "" tarballSHA256 Nothing
   return $ Package source False pkgDesc
 
 getPackageFromDb :: DB.HackageDB -> PackageIdentifier -> IO Package

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-12.2
+resolver: lts-12.16
 extra-deps:
   - cabal2nix-2.13
   - hpack-0.31.1
@@ -12,3 +12,6 @@ extra-deps:
       - gitlib
       - gitlib-libgit2
 
+nix:
+  enable: false  # run stack with --nix to enable
+  packages: [ icu, openssl, zlib ]

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,9 @@
 resolver: lts-12.2
 extra-deps:
-  - yaml-0.8.31.1
+  - cabal2nix-2.13
+  - hpack-0.31.1
+  - infer-license-0.2.0
+  - yaml-0.10.0
   - git: https://github.com/fpco/stackage-curator.git
     commit: 73c5ed06602990c33d3fec1711e27875f283b6bf
   - git: https://github.com/jwiegley/gitlib.git

--- a/stackage2nix.cabal
+++ b/stackage2nix.cabal
@@ -35,7 +35,7 @@ library
                      , QuickCheck
                      , aeson
                      , bytestring
-                     , cabal2nix >= 2.7.2
+                     , cabal2nix >= 2.11
                      , containers
                      , deepseq
                      , distribution-nixpkgs >= 1.1


### PR DESCRIPTION
The function `configureCabalFlags` uses a list of packages that should be called with certain flags when passing them to `cabal2nix`.
    
For example, for `hslua`, it specifies that it is to used the "system" version of lua (the one provided by nix) and not the version of lua that comes embedded in the package. Notice that cabal2nix assumes assumes this flag in newer versions of its `postProcess` method, and if the flag is not given, it will fail attempting to replace package "lua" by "lua_5_3". In any case, a derivation for `hslua` that doesn't include `lua_5_3` as a dependency would be incomplete.

This PR also contains two minor changes (they could be moved to a different PR if needed):
  - Make `stackage2nix` work with more recent versions of `cabal2nix`, which introduced a couple of api-breaking changes.
  - Make it easier to build with `stack --nix`.